### PR TITLE
Fix to Issue 20 - Avoid adding frames for classes with a Java version gr...

### DIFF
--- a/src/java/org/deuce/transform/asm/ExcludeIncludeStore.java
+++ b/src/java/org/deuce/transform/asm/ExcludeIncludeStore.java
@@ -23,6 +23,8 @@ public class ExcludeIncludeStore {
 		excludeIncludeStore.excludeClass.add("java/lang/Object");
 		excludeIncludeStore.excludeClass.add("java/lang/Thread");
 		excludeIncludeStore.excludeClass.add("java/lang/Throwable");
+		excludeIncludeStore.excludeClass.add("javax/management/remote/rmi/_RMIConnection_Stub");
+		excludeIncludeStore.excludeClass.add("org/omg/stub/javax/management/remote/rmi/_RMIConnection_Stub");
 		//Always ignore TransactionException so user can explicitly throw this exception
 		excludeIncludeStore.excludeClass.add(TransactionException.TRANSACTION_EXCEPTION_INTERNAL);
 		excludeIncludeStore.excludeClass.add(AbortTransactionException.ABORT_TRANSACTION_EXCEPTION_INTERNAL);

--- a/src/java/org/deuce/transform/asm/FramesCodeVisitor.java
+++ b/src/java/org/deuce/transform/asm/FramesCodeVisitor.java
@@ -29,7 +29,7 @@ public class FramesCodeVisitor extends ClassAdapter{
 	public void visit(final int version, final int access, final String name,
 			final String signature, final String superName, final String[] interfaces) {
 		
-		if(version == JAVA6_VERSION) // already has frames 
+		if(version >= JAVA6_VERSION) // already has frames 
 			throw VersionException.INSTANCE;
 		
 		super.visit(JAVA5_VERSION, access, name, signature, superName, interfaces);


### PR DESCRIPTION
...eater than 1.5.:
- org.deuce.transform.asm.FramesCodeVisitor – in the visit method we corrected the verification of the Java code version from == operator, to >= of Java 6 version. Yet, this change makes the instrumentation to fail for several classes of the Java RMI packages, with a NullPointerException thrown by the AnalyzerAdapter.
- org.deuce.objectweb.asm.commons.AnalyzerAdapter – we included the same fixes provided by the release 3.3 of the ASM.
- org.deuce.transform.asm.ExcludeIncludeStore - we added the _RMIConnection_Stub to the collection of excluded classes, because we cannot correctly apply the org.deuce.transform.asm.ClassTransformer instrumentation to this class – the stack of the AnalyzerAdapter is null when we access it in the visitInsn method of the DuplicateMethod class.
